### PR TITLE
#69 - 대댓글 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
@@ -10,6 +10,7 @@ public record ArticleCommentDto(
         Long id,
         Long articleId,
         UserAccountDto userAccountDto,
+        Long parentCommentId,
         String content,
         LocalDateTime createdAt,
         String createdBy,
@@ -17,11 +18,16 @@ public record ArticleCommentDto(
         String modifiedBy
 ) {
     public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
-        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+        return ArticleCommentDto.of(null, articleId, userAccountDto, null, content, null, null, null, null);
     }
-
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content) {
+        return ArticleCommentDto.of(null, articleId, userAccountDto, parentCommentId, content, null, null, null, null);
+    }
     public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
+        return ArticleCommentDto.of(id, articleId, userAccountDto, null, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId,content, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
     public static ArticleCommentDto from(ArticleComment entity) {
@@ -29,6 +35,7 @@ public record ArticleCommentDto(
                 entity.getId(),
                 entity.getArticle().getId(),
                 UserAccountDto.from(entity.getUserAccount()),
+                entity.getParentCommentId(),
                 entity.getContent(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),

--- a/src/main/java/com/fastcampus/projectboard/dto/request/ArticleCommentRequest.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/request/ArticleCommentRequest.java
@@ -4,16 +4,20 @@ import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
 
 public record ArticleCommentRequest(
-    Long articleId, String content
+    Long articleId, Long parentCommentId, String content
 ) {
     public static ArticleCommentRequest of(Long articleId, String content) {
-        return new ArticleCommentRequest(articleId, content);
+        return ArticleCommentRequest.of(articleId, null, content);
+    }
+    public static ArticleCommentRequest of(Long articleId, Long parentCommentId, String content) {
+        return new ArticleCommentRequest(articleId, parentCommentId, content);
     }
 
     public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
         return ArticleCommentDto.of(
                 articleId,
                 userAccountDto,
+                parentCommentId,
                 content
         );
     }

--- a/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/response/ArticleCommentResponse.java
@@ -1,7 +1,11 @@
 package com.fastcampus.projectboard.dto.response;
 
+import com.fastcampus.projectboard.domain.ArticleComment;
 import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 
 public record ArticleCommentResponse(
         Long id,
@@ -9,24 +13,41 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
-        String userId
-)  {
+        String userId,
+        Long parentCommentId,
+        Set<ArticleCommentResponse> childComments
+) {
 
-        public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
-            return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
-        }
-        public static ArticleCommentResponse from(ArticleCommentDto dto) {
-            String nickname = dto.userAccountDto().nickname();
-            if (nickname == null || nickname.isBlank()) {
-                nickname = dto.userAccountDto().userId();
-            }
-            return new ArticleCommentResponse(
-                    dto.id(),
-                    dto.content(),
-                    dto.createdAt(),
-                    dto.userAccountDto().email(),
-                    nickname,
-                    dto.userAccountDto().userId()
-            );
-        }
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return ArticleCommentResponse.of(id, content, createdAt, email, nickname, userId, null);
     }
+
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId, Long parentCommentId) {
+        Comparator<ArticleCommentResponse> childCommentComparator = Comparator
+                .comparing(ArticleCommentResponse::createdAt)
+                .thenComparingLong(ArticleCommentResponse::id);
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId, parentCommentId, new TreeSet<>(childCommentComparator));
+    }
+
+    public static ArticleCommentResponse from(ArticleCommentDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return ArticleCommentResponse.of(
+                dto.id(),
+                dto.content(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname,
+                dto.userAccountDto().userId(),
+                dto.parentCommentId()
+        );
+    }
+
+    public boolean hasParentComment() {
+        return parentCommentId != null;
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -1,11 +1,12 @@
 package com.fastcampus.projectboard.dto.response;
 
+import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.HashtagDto;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public record ArticleWithCommentsResponse(
@@ -43,5 +44,26 @@ public record ArticleWithCommentsResponse(
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))
         );
+    }
+
+    private static Set<ArticleCommentResponse> organizeChildComments(Set<ArticleCommentDto> dtos) {
+        Map<Long, ArticleCommentResponse> map = dtos.stream()
+                .map(ArticleCommentResponse::from)
+                .collect(Collectors.toMap(ArticleCommentResponse::id, Function.identity()));
+
+        map.values().stream()
+                .filter(ArticleCommentResponse::hasParentComment)
+                .forEach(comment -> {
+                   ArticleCommentResponse parentComment = map.get(comment.parentCommentId());
+                   parentComment.childComments().add(comment);
+                });
+        return map.values().stream()
+                .filter(comment -> !comment.hasParentComment())
+                .collect(Collectors.toCollection(() ->
+                        new TreeSet<>(Comparator.comparing(ArticleCommentResponse::createdAt)
+                                .reversed()
+                                .thenComparingLong(ArticleCommentResponse::id)
+                        )
+                ));
     }
 }

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleCommentControllerTest.java
@@ -43,7 +43,7 @@ class ArticleCommentControllerTest {
     }
 
 
-    @WithUserDetails(value = "unoTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "solheTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
     @Test
     void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
@@ -64,27 +64,48 @@ class ArticleCommentControllerTest {
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 
-//    @WithUserDetails(value = "unoTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @DisplayName("[view][GET] 댓글 삭제 - 정상 호출")
-//    @Test
-//    void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
-//        // Given
-//        long articleId = 1L;
-//        long articleCommentId = 1L;
-//        String userId = "unoTest";
-//        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
-//
-//        // When & Then
-//        mvc.perform(
-//                        post("/comments/" + articleCommentId + "/delete")
-//                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-//                                .content(formDataEncoder.encode(Map.of("articleId", articleId)))
-//                                .with(csrf())
-//                )
-//                .andExpect(status().is3xxRedirection())
-//                .andExpect(view().name("redirect:/articles/" + articleId))
-//                .andExpect(redirectedUrl("/articles/" + articleId));
-//        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
-//    }
-//
+    @WithUserDetails(value = "solheTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view][GET] 댓글 삭제 - 정상 호출")
+    @Test
+    void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
+        // Given
+        long articleId = 1L;
+        long articleCommentId = 1L;
+        String userId = "solheTest";
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
+
+        // When & Then
+        mvc.perform(
+                        post("/comments/" + articleCommentId + "/delete")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(formDataEncoder.encode(Map.of("articleId", articleId)))
+                                .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
+    }
+
+    @WithUserDetails(value = "solheTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view][POST] 대댓글 등록 - 정상 호출")
+    @Test
+    void givenArticleCommentInfoWithParentCommentId_whenRequesting_thenSavesNewChildComment() throws Exception {
+        // given
+        long articleId = 1L;
+        ArticleCommentRequest request = ArticleCommentRequest.of(articleId, 1L, "test comment");
+        willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
+        // when & then
+        mvc.perform(
+                post("/comments/new")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(request))
+                        .with(csrf())
+        )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+        then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
+    }
+
 }


### PR DESCRIPTION
부모/자식 관계를 만들면서 entity <-> dto 간 변환 로직,댓글 서비스에서 댓글과 대댓글을 저장하고 삭제하는 방법,댓글과 대댓글을 db 데이터로부터 변환할 때 서로 계층 구조를 만들고 각각 정렬하는 과정을 구현